### PR TITLE
Migrate ws headers.Host to independent host

### DIFF
--- a/webroot/helper.js
+++ b/webroot/helper.js
@@ -205,7 +205,7 @@ function convert_uri_to_xray_json(uri, optional_settings) {
             } else if (net === 'ws') {
                 outbound.streamSettings.wsSettings = {
                     path: p.get('path') || "/",
-                    headers: { Host: p.get('host') || "" }
+                    host: p.get('host') || ""
                 };
             } else if (net === 'httpupgrade') {
                 outbound.streamSettings.httpupgradeSettings = {


### PR DESCRIPTION
```text
2026/06/24 19:41:40.827902 [Warning] common/errors: This feature "host" in "headers" is deprecated, will be removed soon and being migrated to independent "host". Please update your config(s) according to release note and documentation before removal.
```