### PR TITLE
Fixes "ip6tables: No chain/target/match by that name" error on Android devices lacking `xt_addrtype` kernel module support.

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -210,7 +210,7 @@ clear_routing_rules() {
     $ip6tables -t mangle -D PREROUTING ! -i xraytun0 -d ::1/128 -j RETURN
     $ip6tables -t mangle -D PREROUTING ! -i xraytun0 -d fe80::/10 -j RETURN
     $ip6tables -t mangle -D PREROUTING ! -i xraytun0 -d fc00::/7 -j RETURN
-    $ip6tables -t mangle -D PREROUTING ! -i xraytun0 -m addrtype ! --src-type LOCAL -j MARK --set-xmark 1
+    $ip6tables -t mangle -D PREROUTING ! -i xraytun0 -j MARK --set-xmark 1
 
     # Down the tun device
     $ip link set dev xraytun0 down
@@ -307,7 +307,7 @@ do_job() {
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d ::1/128 -j RETURN
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d fe80::/10 -j RETURN
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d fc00::/7 -j RETURN
-            $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -m addrtype ! --src-type LOCAL -j MARK --set-xmark 1
+            $ip6tables -t mangle -A PREROUTING -m addrtype --src-type LOCAL -j RETURN
         fi
     fi
     if [ "$content" = "stop" ]; then

--- a/service.sh
+++ b/service.sh
@@ -307,7 +307,7 @@ do_job() {
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d ::1/128 -j RETURN
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d fe80::/10 -j RETURN
             $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -d fc00::/7 -j RETURN
-            $ip6tables -t mangle -A PREROUTING -m addrtype --src-type LOCAL -j RETURN
+            $ip6tables -t mangle -A PREROUTING ! -i xraytun0 -j MARK --set-xmark 1
         fi
     fi
     if [ "$content" = "stop" ]; then


### PR DESCRIPTION
- Replace `-m addrtype ! --src-type LOCAL` with standard interface-based rule (`! -i xraytun0`) in IPv6 mangle PREROUTING.
- Fixes "ip6tables: No chain/target/match by that name" error on Android devices lacking `xt_addrtype` kernel module support.
- Updated both routing injection and cleanup (iptables -D) rules.

```text
+ /system/bin/ip -6 rule add fwmark 1 table 100 priority 1010
+ /system/bin/ip6tables -t mangle -N XRAY_MARK
+ /system/bin/ip6tables -t mangle -A XRAY_MARK -m mark --mark 255 -j RETURN
+ /system/bin/ip6tables -t mangle -A XRAY_MARK -m owner --uid-owner 1000 -j MARK --set-xmark 1
+ /system/bin/ip6tables -t mangle -A XRAY_MARK -m owner --uid-owner 1052 -j MARK --set-xmark 1
+ /system/bin/ip6tables -t mangle -A XRAY_MARK -m owner --uid-owner 9999-2147483647 -j MARK --set-xmark 1
+ /system/bin/ip6tables -t mangle -A OUTPUT -j XRAY_MARK
+ /system/bin/ip6tables -I FORWARD -i xraytun0 -j ACCEPT
+ /system/bin/ip6tables -I FORWARD -o xraytun0 -j ACCEPT
+ /system/bin/ip6tables -t mangle -I PREROUTING -p udp --dport 53 -j MARK --set-xmark 1
+ /system/bin/ip6tables -t mangle -I PREROUTING -p tcp --dport 53 -j MARK --set-xmark 1
+ /system/bin/ip6tables -t mangle -A PREROUTING '!' -i xraytun0 -d ::1/128 -j RETURN
+ /system/bin/ip6tables -t mangle -A PREROUTING '!' -i xraytun0 -d fe80::/10 -j RETURN
+ /system/bin/ip6tables -t mangle -A PREROUTING '!' -i xraytun0 -d fc00::/7 -j RETURN
+ /system/bin/ip6tables -t mangle -A PREROUTING '!' -i xraytun0 -m addrtype '!' --src-type LOCAL -j MARK --set-xmark 1
ip6tables: No chain/target/match by that name
```